### PR TITLE
UI/UX pass: accessibility, mobile nav, and Soft Rosé rebrand

### DIFF
--- a/app/[locale]/cart/page.tsx
+++ b/app/[locale]/cart/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 import { use, useEffect } from 'react';
 import Link from 'next/link';
+import { ShoppingBag } from 'lucide-react';
 import { isLocale, type Locale, defaultLocale } from '@/lib/i18n/config';
 import { getDictionary } from '@/lib/i18n/dictionaries';
 import { useCart } from '@/features/cart/use-cart';
+import { Button } from '@/components/ui/button';
 import { CartLineItem } from '@/components/commerce/cart-line-item';
 import { OrderSummary } from '@/components/commerce/order-summary';
 import { useAnalytics } from '@/lib/analytics/use-analytics';
@@ -38,9 +40,14 @@ export default function CartPage({ params }: { params: Promise<{ locale: string 
 
   if (lines.length === 0) {
     return (
-      <div className="py-16 text-center">
-        <p className="mb-4 text-lg">{dict.cart.empty}</p>
-        <Link href={`/${locale}`} className="underline">{dict.common.shopNow}</Link>
+      <div className="flex flex-col items-center py-16 text-center">
+        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+          <ShoppingBag className="h-7 w-7 text-muted-foreground" />
+        </div>
+        <p className="mb-6 text-lg">{dict.cart.empty}</p>
+        <Button asChild className="h-11 px-6 text-base">
+          <Link href={`/${locale}`}>{dict.common.shopNow}</Link>
+        </Button>
       </div>
     );
   }

--- a/app/[locale]/checkout/page.tsx
+++ b/app/[locale]/checkout/page.tsx
@@ -26,7 +26,16 @@ export default function CheckoutPage({ params }: { params: Promise<{ locale: str
   const router = useRouter();
   const { lines, subtotal, currency } = useCart();
   const { track } = useAnalytics();
-  const { register, handleSubmit, formState: { errors } } = useForm<CheckoutForm>({ resolver: zodResolver(checkoutSchema) });
+  const { register, handleSubmit, formState: { errors, isSubmitted } } = useForm<CheckoutForm>({ resolver: zodResolver(checkoutSchema) });
+
+  const fields = [
+    { name: 'fullName' as const, label: dict.checkout.fullName, message: dict.checkout.errors.required, autoComplete: 'name', type: 'text' },
+    { name: 'email' as const, label: dict.checkout.email, message: dict.checkout.errors.invalidEmail, autoComplete: 'email', type: 'email' },
+    { name: 'address' as const, label: dict.checkout.address, message: dict.checkout.errors.required, autoComplete: 'street-address', type: 'text' },
+    { name: 'city' as const, label: dict.checkout.city, message: dict.checkout.errors.required, autoComplete: 'address-level2', type: 'text' },
+    { name: 'phone' as const, label: dict.checkout.phone, message: dict.checkout.errors.required, autoComplete: 'tel', type: 'tel' },
+  ];
+  const erroredFields = fields.filter((f) => errors[f.name]);
 
   useEffect(() => {
     track({ name: 'begin_checkout', params: { currency, value: subtotal, items: cartLinesToGa4Items(lines) } });
@@ -42,15 +51,43 @@ export default function CheckoutPage({ params }: { params: Promise<{ locale: str
 
   return (
     <div className="grid gap-8 md:grid-cols-3">
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 md:col-span-2">
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4 md:col-span-2">
         <h1 className="text-2xl font-bold">{dict.checkout.title}</h1>
-        <div><Input placeholder={dict.checkout.fullName} {...register('fullName')} />{errors.fullName && <p className="text-xs text-red-600">{dict.checkout.errors.required}</p>}</div>
-        <div><Input placeholder={dict.checkout.email} {...register('email')} />{errors.email && <p className="text-xs text-red-600">{dict.checkout.errors.invalidEmail}</p>}</div>
-        <div><Input placeholder={dict.checkout.address} {...register('address')} />{errors.address && <p className="text-xs text-red-600">{dict.checkout.errors.required}</p>}</div>
-        <div><Input placeholder={dict.checkout.city} {...register('city')} />{errors.city && <p className="text-xs text-red-600">{dict.checkout.errors.required}</p>}</div>
-        <div><Input placeholder={dict.checkout.phone} {...register('phone')} />{errors.phone && <p className="text-xs text-red-600">{dict.checkout.errors.required}</p>}</div>
+
+        {isSubmitted && erroredFields.length > 0 ? (
+          <div role="alert" className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm">
+            <p className="font-medium text-destructive">{dict.checkout.errors.summary}</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5">
+              {erroredFields.map((f) => (
+                <li key={f.name}>
+                  <a href={`#${f.name}`} className="text-destructive underline">{f.label}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {fields.map((f) => {
+          const hasError = Boolean(errors[f.name]);
+          return (
+            <div key={f.name} className="space-y-1.5">
+              <label htmlFor={f.name} className="text-sm font-medium">{f.label}</label>
+              <Input
+                id={f.name}
+                type={f.type}
+                autoComplete={f.autoComplete}
+                aria-invalid={hasError}
+                aria-describedby={hasError ? `${f.name}-error` : undefined}
+                className="h-11"
+                {...register(f.name)}
+              />
+              {hasError ? <p id={`${f.name}-error`} className="text-xs text-destructive">{f.message}</p> : null}
+            </div>
+          );
+        })}
+
         <p className="text-sm text-muted-foreground">{dict.checkout.payNote}</p>
-        <Button type="submit" className="w-full">{dict.checkout.placeOrder}</Button>
+        <Button type="submit" className="h-11 w-full text-base">{dict.checkout.placeOrder}</Button>
       </form>
       <OrderSummary subtotal={subtotal} currency={currency} locale={locale} dict={dict} />
     </div>

--- a/app/[locale]/checkout/success/page.tsx
+++ b/app/[locale]/checkout/success/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { use, useEffect, useState } from 'react';
 import Link from 'next/link';
+import { CheckCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { isLocale, type Locale, defaultLocale } from '@/lib/i18n/config';
 import { getDictionary } from '@/lib/i18n/dictionaries';
 import { useCart } from '@/features/cart/use-cart';
@@ -32,10 +34,15 @@ export default function SuccessPage({ params }: { params: Promise<{ locale: stri
   }, []);
 
   return (
-    <div className="py-16 text-center">
+    <div className="flex flex-col items-center py-16 text-center">
+      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
+        <CheckCircle2 className="h-8 w-8 text-primary" />
+      </div>
       <h1 className="mb-2 text-2xl font-bold">{dict.checkout.success}</h1>
       {orderId ? <p className="text-muted-foreground">{dict.checkout.orderId}: {orderId}</p> : null}
-      <Link href={`/${locale}`} className="mt-6 inline-block underline">{dict.common.shopNow}</Link>
+      <Button asChild className="mt-6 h-11 px-6 text-base">
+        <Link href={`/${locale}`}>{dict.common.shopNow}</Link>
+      </Button>
     </div>
   );
 }

--- a/app/[locale]/collection/[slug]/page.tsx
+++ b/app/[locale]/collection/[slug]/page.tsx
@@ -51,7 +51,14 @@ export default async function CollectionPage({
     <div>
       <h1 className="mb-4 text-2xl font-bold">{resolveTitle(dict, collection.title)}</h1>
       <CollectionFilters dict={dict} />
-      <ProductGrid products={products} locale={l} listId={collection.slug} />
+      {products.length === 0 ? (
+        <p className="py-16 text-center text-muted-foreground">{dict.collection.noResults}</p>
+      ) : (
+        <>
+          <p className="mb-4 text-sm text-muted-foreground">{products.length} {dict.collection.productsLabel}</p>
+          <ProductGrid products={products} locale={l} listId={collection.slug} />
+        </>
+      )}
     </div>
   );
 }

--- a/app/[locale]/product/[slug]/page.tsx
+++ b/app/[locale]/product/[slug]/page.tsx
@@ -31,8 +31,8 @@ export default async function ProductPage({ params }: { params: Promise<{ locale
             <RatingStars rating={product.rating} />
             <span className="text-sm text-muted-foreground">({product.reviewCount})</span>
           </div>
+          <p className="leading-relaxed text-muted-foreground">{product.description}</p>
           <AddToCart product={product} locale={l} dict={dict} />
-          <p className="text-sm text-muted-foreground">{product.description}</p>
         </div>
       </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,9 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-sans);
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  --font-heading: var(--font-fraunces);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -49,24 +49,25 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  /* Soft Rosé / K-beauty — warm white, dusty-rose accent, blush neutrals, plum-ink text */
+  --background: oklch(0.993 0.004 40);
+  --foreground: oklch(0.25 0.02 350);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.25 0.02 350);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.6 0.118 184.704);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.25 0.02 350);
+  --primary: oklch(0.58 0.14 8);
+  --primary-foreground: oklch(0.99 0.003 40);
+  --secondary: oklch(0.955 0.012 350);
+  --secondary-foreground: oklch(0.3 0.02 350);
+  --muted: oklch(0.94 0.012 350);
+  --muted-foreground: oklch(0.48 0.03 350);
+  --accent: oklch(0.955 0.014 350);
+  --accent-foreground: oklch(0.3 0.02 350);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --border: oklch(0.9 0.014 350);
+  --input: oklch(0.9 0.014 350);
+  --ring: oklch(0.58 0.14 8);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -84,24 +85,24 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.704 0.14 182.503);
-  --primary-foreground: oklch(0.145 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --background: oklch(0.19 0.014 340);
+  --foreground: oklch(0.97 0.005 350);
+  --card: oklch(0.24 0.016 340);
+  --card-foreground: oklch(0.97 0.005 350);
+  --popover: oklch(0.24 0.016 340);
+  --popover-foreground: oklch(0.97 0.005 350);
+  --primary: oklch(0.72 0.13 8);
+  --primary-foreground: oklch(0.19 0.014 340);
+  --secondary: oklch(0.28 0.014 340);
+  --secondary-foreground: oklch(0.97 0.005 350);
+  --muted: oklch(0.28 0.014 340);
+  --muted-foreground: oklch(0.74 0.02 345);
+  --accent: oklch(0.28 0.014 340);
+  --accent-foreground: oklch(0.97 0.005 350);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
+  --border: oklch(1 0 0 / 12%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --ring: oklch(0.72 0.13 8);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -126,5 +127,8 @@
   }
   html {
     @apply font-sans;
+  }
+  h1, h2, h3 {
+    @apply font-heading;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,19 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Fraunces, Geist_Mono } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { CartProvider } from "@/features/cart/cart-context";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
+  display: "swap",
+});
+
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
+  subsets: ["latin"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
@@ -23,7 +30,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${inter.variable} ${fraunces.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <CartProvider>

--- a/components/commerce/add-to-cart.tsx
+++ b/components/commerce/add-to-cart.tsx
@@ -5,6 +5,7 @@ import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
 import { VariantSelector } from './variant-selector';
 import { PriceTag } from './price-tag';
+import { QuantityStepper } from './quantity-stepper';
 import { Button } from '@/components/ui/button';
 import { useCart } from '@/features/cart/use-cart';
 import { useAnalytics } from '@/lib/analytics/use-analytics';
@@ -36,13 +37,14 @@ export function AddToCart({ product, locale, dict }: { product: Product; locale:
       <VariantSelector product={product} dict={dict} onVariantChange={setVariant} />
       <div className="flex items-center gap-3">
         <span className="text-sm font-medium">{dict.pdp.quantity}</span>
-        <div className="flex items-center rounded border">
-          <button aria-label="Decrease" onClick={() => setQty((q) => Math.max(1, q - 1))} className="px-3 py-1">-</button>
-          <span className="w-8 text-center">{qty}</span>
-          <button aria-label="Increase" onClick={() => setQty((q) => q + 1)} className="px-3 py-1">+</button>
-        </div>
+        <QuantityStepper
+          value={qty}
+          onChange={(next) => setQty(Math.max(1, next))}
+          decreaseLabel={dict.common.decreaseQty}
+          increaseLabel={dict.common.increaseQty}
+        />
       </div>
-      <Button onClick={onAdd} className="w-full">{dict.common.addToCart}</Button>
+      <Button onClick={onAdd} className="h-11 w-full text-base">{dict.common.addToCart}</Button>
     </div>
   );
 }

--- a/components/commerce/cart-line-item.tsx
+++ b/components/commerce/cart-line-item.tsx
@@ -3,6 +3,7 @@ import type { CartLine } from '@/features/cart/cart.types';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
 import { formatPrice } from '@/lib/utils/format';
+import { QuantityStepper } from './quantity-stepper';
 
 export function CartLineItem({
   line, locale, dict, onQty, onRemove,
@@ -19,11 +20,13 @@ export function CartLineItem({
       <div className="flex-1">
         <p className="font-medium">{line.name}</p>
         <p className="text-sm text-muted-foreground">{line.packSize}{line.color ? ` · ${line.color}` : ''}</p>
-        <div className="mt-2 flex items-center rounded border w-fit">
-          <button aria-label="Decrease" onClick={() => onQty(line.variantId, line.quantity - 1)} className="px-2">-</button>
-          <span className="w-8 text-center">{line.quantity}</span>
-          <button aria-label="Increase" onClick={() => onQty(line.variantId, line.quantity + 1)} className="px-2">+</button>
-        </div>
+        <QuantityStepper
+          className="mt-2"
+          value={line.quantity}
+          onChange={(next) => onQty(line.variantId, next)}
+          decreaseLabel={dict.common.decreaseQty}
+          increaseLabel={dict.common.increaseQty}
+        />
       </div>
       <div className="text-right">
         <p className="font-semibold">{formatPrice(line.unitPrice * line.quantity, line.currency, locale)}</p>

--- a/components/commerce/collection-carousel.tsx
+++ b/components/commerce/collection-carousel.tsx
@@ -28,8 +28,8 @@ export function CollectionCarousel({
             ))}
           </div>
         </div>
-        <button aria-label="Previous slide" onClick={() => embla?.scrollPrev()} className="absolute -left-3 top-1/3 rounded-full bg-white/90 p-2 shadow"><ChevronLeft className="h-5 w-5" /></button>
-        <button aria-label="Next slide" onClick={() => embla?.scrollNext()} className="absolute -right-3 top-1/3 rounded-full bg-white/90 p-2 shadow"><ChevronRight className="h-5 w-5" /></button>
+        <button aria-label="Previous slide" onClick={() => embla?.scrollPrev()} className="absolute -left-3 top-1/3 flex h-11 w-11 items-center justify-center rounded-full bg-background/90 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background"><ChevronLeft className="h-5 w-5" /></button>
+        <button aria-label="Next slide" onClick={() => embla?.scrollNext()} className="absolute -right-3 top-1/3 flex h-11 w-11 items-center justify-center rounded-full bg-background/90 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background"><ChevronRight className="h-5 w-5" /></button>
       </div>
     </section>
   );

--- a/components/commerce/hero-carousel.tsx
+++ b/components/commerce/hero-carousel.tsx
@@ -19,10 +19,10 @@ export function HeroCarousel({ slides }: { slides: { image: string; href: string
           ))}
         </div>
       </div>
-      <button aria-label="Previous slide" onClick={() => embla?.scrollPrev()} className="absolute left-3 top-1/2 -translate-y-1/2 rounded-full bg-white/80 p-2">
+      <button aria-label="Previous slide" onClick={() => embla?.scrollPrev()} className="absolute left-3 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background">
         <ChevronLeft className="h-5 w-5" />
       </button>
-      <button aria-label="Next slide" onClick={() => embla?.scrollNext()} className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full bg-white/80 p-2">
+      <button aria-label="Next slide" onClick={() => embla?.scrollNext()} className="absolute right-3 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background">
         <ChevronRight className="h-5 w-5" />
       </button>
     </div>

--- a/components/commerce/order-summary.tsx
+++ b/components/commerce/order-summary.tsx
@@ -17,7 +17,7 @@ export function OrderSummary({
         <span className="font-semibold">{formatPrice(subtotal, currency, locale)}</span>
       </div>
       {ctaHref && ctaLabel ? (
-        <Button asChild className="w-full">
+        <Button asChild className="h-11 w-full text-base">
           <Link href={ctaHref}>{ctaLabel}</Link>
         </Button>
       ) : null}

--- a/components/commerce/price-tag.tsx
+++ b/components/commerce/price-tag.tsx
@@ -17,7 +17,7 @@ export function PriceTag({
           <span className="text-sm text-muted-foreground line-through">
             {formatPrice(compareAtPrice, currency, locale)}
           </span>
-          <span className="text-xs font-medium text-red-600">-{discount}%</span>
+          <span className="text-xs font-medium text-destructive">-{discount}%</span>
         </>
       ) : null}
     </div>

--- a/components/commerce/product-gallery.tsx
+++ b/components/commerce/product-gallery.tsx
@@ -6,15 +6,15 @@ import { cn } from '@/lib/utils/cn';
 export function ProductGallery({ images, alt }: { images: string[]; alt: string }) {
   const [active, setActive] = useState(0);
   return (
-    <div className="flex gap-4">
-      <div className="flex flex-col gap-2">
+    <div className="flex flex-col-reverse gap-4 md:flex-row">
+      <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-visible">
         {images.map((src, i) => (
-          <button key={src} onClick={() => setActive(i)} className={cn('relative h-16 w-16 overflow-hidden rounded border', active === i && 'ring-2 ring-primary')}>
+          <button key={src} aria-label={`${alt} ${i + 1}`} aria-current={active === i} onClick={() => setActive(i)} className={cn('relative h-16 w-16 shrink-0 overflow-hidden rounded border', active === i && 'ring-2 ring-primary')}>
             <Image src={src} alt={`${alt} ${i + 1}`} fill className="object-cover" sizes="64px" />
           </button>
         ))}
       </div>
-      <div className="relative aspect-square flex-1 overflow-hidden rounded-lg bg-muted">
+      <div className="relative aspect-square w-full flex-1 overflow-hidden rounded-lg bg-muted">
         {images[active] ? <Image src={images[active]} alt={alt} fill className="object-cover" sizes="(max-width:768px) 100vw, 50vw" priority /> : null}
       </div>
     </div>

--- a/components/commerce/quantity-stepper.tsx
+++ b/components/commerce/quantity-stepper.tsx
@@ -1,0 +1,30 @@
+import { Minus, Plus } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
+
+/**
+ * Shared quantity control with 44px touch targets. Emits the raw next value;
+ * the parent decides clamping (PDP clamps at 1) or removal (cart removes at 0).
+ */
+export function QuantityStepper({
+  value, onChange, decreaseLabel, increaseLabel, className,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+  decreaseLabel: string;
+  increaseLabel: string;
+  className?: string;
+}) {
+  const btn =
+    'flex h-11 w-11 items-center justify-center text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring';
+  return (
+    <div className={cn('inline-flex items-center rounded-md border', className)}>
+      <button type="button" aria-label={decreaseLabel} onClick={() => onChange(value - 1)} className={btn}>
+        <Minus className="h-4 w-4" />
+      </button>
+      <span className="w-10 text-center text-sm tabular-nums" aria-live="polite">{value}</span>
+      <button type="button" aria-label={increaseLabel} onClick={() => onChange(value + 1)} className={btn}>
+        <Plus className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/components/commerce/reviews-list.tsx
+++ b/components/commerce/reviews-list.tsx
@@ -7,7 +7,7 @@ export function ReviewsList({ reviews, dict }: { reviews: Review[]; dict: Dictio
     <section className="space-y-4">
       <h2 className="text-xl font-semibold">{dict.pdp.reviews}</h2>
       {reviews.length === 0 ? (
-        <p className="text-sm text-muted-foreground">—</p>
+        <p className="text-sm text-muted-foreground">{dict.pdp.noReviews}</p>
       ) : (
         reviews.map((r) => (
           <div key={r.id} className="border-b pb-4">

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -4,6 +4,7 @@ import { ShoppingCart, User, Search } from 'lucide-react';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
 import { MegaNav } from './mega-nav';
+import { MobileNav } from './mobile-nav';
 import { LocaleSwitcher } from './locale-switcher';
 import { useCart } from '@/features/cart/use-cart';
 
@@ -11,20 +12,25 @@ export function Header({ locale, dict }: { locale: Locale; dict: Dictionary }) {
   const { count } = useCart();
   return (
     <header className="border-b">
-      <div className="mx-auto flex max-w-7xl items-center gap-6 px-4 py-4">
-        <Link href={`/${locale}`} className="text-xl font-bold">Vivimoon</Link>
+      <div className="mx-auto flex max-w-7xl items-center gap-4 px-4 py-4 md:gap-6">
+        <MobileNav locale={locale} dict={dict} />
+        <Link href={`/${locale}`} className="font-heading text-xl font-bold">Vivimoon</Link>
         <MegaNav locale={locale} dict={dict} />
-        <div className="ml-auto flex items-center gap-4">
+        <div className="ml-auto flex items-center gap-1 md:gap-4">
           <div className="hidden items-center gap-2 rounded border px-2 md:flex">
             <Search className="h-4 w-4 text-muted-foreground" />
             <input aria-label={dict.common.search} placeholder={dict.common.search} className="bg-transparent py-1 text-sm outline-none" />
           </div>
-          <button aria-label="Account"><User className="h-5 w-5" /></button>
-          <Link href={`/${locale}/cart`} aria-label={dict.cart.title} className="relative">
+          <button aria-label="Account" className="hidden h-11 w-11 items-center justify-center rounded-md hover:bg-muted md:flex">
+            <User className="h-5 w-5" />
+          </button>
+          <Link href={`/${locale}/cart`} aria-label={dict.cart.title} className="relative flex h-11 w-11 items-center justify-center rounded-md hover:bg-muted">
             <ShoppingCart className="h-5 w-5" />
-            {count > 0 ? <span className="absolute -right-2 -top-2 rounded-full bg-primary px-1.5 text-xs text-primary-foreground">{count}</span> : null}
+            {count > 0 ? <span className="absolute right-1.5 top-1.5 min-w-4 rounded-full bg-primary px-1 text-center text-xs leading-4 text-primary-foreground">{count}</span> : null}
           </Link>
-          <LocaleSwitcher currentLocale={locale} />
+          <div className="hidden md:block">
+            <LocaleSwitcher currentLocale={locale} />
+          </div>
         </div>
       </div>
     </header>

--- a/components/layout/mega-nav.tsx
+++ b/components/layout/mega-nav.tsx
@@ -1,17 +1,12 @@
 import Link from 'next/link';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
+import { getNavItems } from './nav-items';
 
 export function MegaNav({ locale, dict }: { locale: Locale; dict: Dictionary }) {
-  const items = [
-    { label: dict.collection.newArrivals, slug: 'new-arrivals' },
-    { label: dict.collection.bestsellers, slug: 'bestsellers' },
-    { label: dict.collection.colored, slug: 'colored-lenses' },
-    { label: dict.collection.daily, slug: 'daily-lenses' },
-    { label: dict.nav.sale, slug: 'sale' },
-  ];
+  const items = getNavItems(dict);
   return (
-    <nav className="flex min-w-0 gap-6 overflow-x-auto">
+    <nav className="hidden min-w-0 gap-6 overflow-x-auto md:flex">
       {items.map((it) => (
         <Link key={it.slug} href={`/${locale}/collection/${it.slug}`} className="text-sm font-medium hover:text-primary">
           {it.label}

--- a/components/layout/mobile-nav.tsx
+++ b/components/layout/mobile-nav.tsx
@@ -1,0 +1,56 @@
+'use client';
+import Link from 'next/link';
+import { Menu, Search } from 'lucide-react';
+import type { Locale } from '@/lib/i18n/config';
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+import { getNavItems } from './nav-items';
+import { LocaleSwitcher } from './locale-switcher';
+import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+
+export function MobileNav({ locale, dict }: { locale: Locale; dict: Dictionary }) {
+  const items = getNavItems(dict);
+  return (
+    <Sheet>
+      <SheetTrigger
+        aria-label={dict.common.menu}
+        className="flex h-11 w-11 items-center justify-center rounded-md hover:bg-muted md:hidden"
+      >
+        <Menu className="h-5 w-5" />
+      </SheetTrigger>
+      <SheetContent side="left" className="w-80 max-w-[85vw]">
+        <SheetHeader className="border-b">
+          <SheetTitle>Vivimoon</SheetTitle>
+        </SheetHeader>
+
+        <div className="px-4">
+          {/* Search shares the storefront's search field; submission wiring is a follow-up. */}
+          <form onSubmit={(e) => e.preventDefault()} className="flex items-center gap-2 rounded-md border px-3">
+            <Search className="h-4 w-4 text-muted-foreground" />
+            <input
+              aria-label={dict.common.search}
+              placeholder={dict.common.search}
+              className="h-11 flex-1 bg-transparent text-sm outline-none"
+            />
+          </form>
+        </div>
+
+        <nav className="flex flex-col px-2">
+          {items.map((it) => (
+            <SheetClose asChild key={it.slug}>
+              <Link
+                href={`/${locale}/collection/${it.slug}`}
+                className="flex min-h-11 items-center rounded-md px-2 text-base font-medium hover:bg-muted"
+              >
+                {it.label}
+              </Link>
+            </SheetClose>
+          ))}
+        </nav>
+
+        <div className="mt-auto border-t p-4">
+          <LocaleSwitcher currentLocale={locale} />
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/layout/nav-items.ts
+++ b/components/layout/nav-items.ts
@@ -1,0 +1,14 @@
+import type { Dictionary } from '@/lib/i18n/dictionaries';
+
+export type NavItem = { label: string; slug: string };
+
+/** Primary storefront navigation, shared by the desktop MegaNav and the mobile drawer. */
+export function getNavItems(dict: Dictionary): NavItem[] {
+  return [
+    { label: dict.collection.newArrivals, slug: 'new-arrivals' },
+    { label: dict.collection.bestsellers, slug: 'bestsellers' },
+    { label: dict.collection.colored, slug: 'colored-lenses' },
+    { label: dict.collection.daily, slug: 'daily-lenses' },
+    { label: dict.nav.sale, slug: 'sale' },
+  ];
+}

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -1,10 +1,11 @@
 export const en = {
   nav: { new: 'New', men: 'Men', women: 'Women', sport: 'Sport', accessories: 'Accessories', sale: 'Sale' },
-  common: { shopNow: 'Shop Now', seeMore: 'See more', addToCart: 'Add to cart', search: 'Search...' },
+  common: { shopNow: 'Shop Now', seeMore: 'See more', addToCart: 'Add to cart', search: 'Search...', decreaseQty: 'Decrease quantity', increaseQty: 'Increase quantity', menu: 'Menu' },
   announcement: { freeShipping: 'Free shipping on orders over $50' },
   collection: {
     newArrivals: 'New Arrivals', bestsellers: 'Bestsellers', sale: 'Sale',
     colored: 'Colored Lenses', daily: 'Daily Lenses',
+    productsLabel: 'products', noResults: 'No products match your filters.',
   },
   filters: {
     type: 'Lens type', replacement: 'Replacement', color: 'Color', sort: 'Sort', clear: 'Clear filters',
@@ -17,6 +18,7 @@ export const en = {
     material: 'Material', waterContent: 'Water content', baseCurve: 'Base curve',
     diameter: 'Diameter', uvProtection: 'UV protection', manufacturer: 'Manufacturer',
     packSize: 'Pack size', color: 'Color', quantity: 'Quantity', freeship: 'Freeship',
+    noReviews: 'No reviews yet.',
   },
   cart: {
     title: 'Your Cart', empty: 'Your cart is empty', subtotal: 'Subtotal',
@@ -26,7 +28,7 @@ export const en = {
     title: 'Checkout', fullName: 'Full name', email: 'Email', address: 'Address',
     city: 'City', phone: 'Phone', placeOrder: 'Place order', payNote: 'Payment is simulated in this demo.',
     success: 'Thank you! Your order is confirmed.', orderId: 'Order ID',
-    errors: { required: 'Required', invalidEmail: 'Invalid email' },
+    errors: { required: 'Required', invalidEmail: 'Invalid email', summary: 'Please fix the following before placing your order.' },
   },
   footer: {
     policies: 'Policies', about: 'About Vivimoon', customerCare: 'Customer Care',

--- a/lib/i18n/dictionaries/vi.ts
+++ b/lib/i18n/dictionaries/vi.ts
@@ -2,11 +2,12 @@ import type { Dictionary } from './en';
 
 export const vi: Dictionary = {
   nav: { new: 'Mới', men: 'Nam', women: 'Nữ', sport: 'Thể thao', accessories: 'Phụ kiện', sale: 'Giảm giá' },
-  common: { shopNow: 'Mua ngay', seeMore: 'Xem thêm', addToCart: 'Thêm vào giỏ', search: 'Tìm kiếm...' },
+  common: { shopNow: 'Mua ngay', seeMore: 'Xem thêm', addToCart: 'Thêm vào giỏ', search: 'Tìm kiếm...', decreaseQty: 'Giảm số lượng', increaseQty: 'Tăng số lượng', menu: 'Menu' },
   announcement: { freeShipping: 'Miễn phí vận chuyển cho đơn từ 1.000.000đ' },
   collection: {
     newArrivals: 'Hàng mới về', bestsellers: 'Bán chạy', sale: 'Giảm giá',
     colored: 'Lens màu', daily: 'Lens hằng ngày',
+    productsLabel: 'sản phẩm', noResults: 'Không có sản phẩm phù hợp với bộ lọc.',
   },
   filters: {
     type: 'Loại lens', replacement: 'Thời gian dùng', color: 'Màu', sort: 'Sắp xếp', clear: 'Xóa bộ lọc',
@@ -19,6 +20,7 @@ export const vi: Dictionary = {
     material: 'Chất liệu', waterContent: 'Độ ẩm', baseCurve: 'Độ cong',
     diameter: 'Đường kính', uvProtection: 'Chống tia UV', manufacturer: 'Nhà sản xuất',
     packSize: 'Quy cách', color: 'Màu', quantity: 'Số lượng', freeship: 'Miễn phí ship',
+    noReviews: 'Chưa có đánh giá.',
   },
   cart: {
     title: 'Giỏ hàng', empty: 'Giỏ hàng trống', subtotal: 'Tạm tính',
@@ -28,7 +30,7 @@ export const vi: Dictionary = {
     title: 'Thanh toán', fullName: 'Họ tên', email: 'Email', address: 'Địa chỉ',
     city: 'Thành phố', phone: 'Số điện thoại', placeOrder: 'Đặt hàng', payNote: 'Thanh toán được mô phỏng trong bản demo.',
     success: 'Cảm ơn bạn! Đơn hàng đã được xác nhận.', orderId: 'Mã đơn hàng',
-    errors: { required: 'Bắt buộc', invalidEmail: 'Email không hợp lệ' },
+    errors: { required: 'Bắt buộc', invalidEmail: 'Email không hợp lệ', summary: 'Vui lòng sửa các mục sau trước khi đặt hàng.' },
   },
   footer: {
     policies: 'Chính sách', about: 'Về Vivimoon', customerCare: 'Chăm sóc khách hàng',


### PR DESCRIPTION
Full UI/UX review of every page, implemented in three tiers. All changes verified: `tsc` clean, 26/26 tests pass, production build succeeds, and desktop/mobile/checkout confirmed in a live browser.

## Tier 1 — Accessibility & touch
- New shared `QuantityStepper` (44px targets, i18n aria-labels, live count) replacing two divergent inline steppers
- Primary CTAs and form inputs raised to 44px minimum
- Checkout form: visible `<label>`s, `aria-invalid` + `aria-describedby`, an **error summary** with in-page anchors, `autoComplete`, `noValidate`
- Header icon buttons and carousel arrows get proper 44px hit areas

## Tier 2 — Mobile layout
- Hamburger **drawer nav** (Radix Sheet) with search + locale switch — fixes "no mobile nav" and "no mobile search"
- Shared `nav-items.ts` so desktop/mobile navigation can't drift
- Product gallery stacks thumbnails on mobile instead of squeezing the image
- Collection page: empty state + result count (no more silent empty grid)

## Tier 3 — Brand & polish
- **Soft Rosé / K-beauty** palette across light + dark tokens
- **Fraunces** display headings + **Inter** body; fixes a pre-existing bug where `--font-sans` was self-referential (font was loaded but never bound)
- Friendlier empty/terminal states (cart, reviews, order success)
- PDP description moved above the buy box
- Discount badge tokenized to theme-aware `destructive` (was raw `text-red-600`)

## Known follow-ups (out of scope here)
- Search fields exist on desktop + mobile but don't submit anywhere — needs a `/search` results route
- Footer policy links (Shipping/Returns/Privacy) still point to home — no policy pages yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)