### PR TITLE
Clean-luxury redesign on shadcn/ui (neutral base + rose accent)

### DIFF
--- a/app/[locale]/cart/page.tsx
+++ b/app/[locale]/cart/page.tsx
@@ -6,6 +6,7 @@ import { isLocale, type Locale, defaultLocale } from '@/lib/i18n/config';
 import { getDictionary } from '@/lib/i18n/dictionaries';
 import { useCart } from '@/features/cart/use-cart';
 import { Button } from '@/components/ui/button';
+import { Empty, EmptyContent, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { CartLineItem } from '@/components/commerce/cart-line-item';
 import { OrderSummary } from '@/components/commerce/order-summary';
 import { useAnalytics } from '@/lib/analytics/use-analytics';
@@ -40,29 +41,35 @@ export default function CartPage({ params }: { params: Promise<{ locale: string 
 
   if (lines.length === 0) {
     return (
-      <div className="flex flex-col items-center py-16 text-center">
-        <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-          <ShoppingBag className="h-7 w-7 text-muted-foreground" />
-        </div>
-        <p className="mb-6 text-lg">{dict.cart.empty}</p>
-        <Button asChild className="h-11 px-6 text-base">
-          <Link href={`/${locale}`}>{dict.common.shopNow}</Link>
-        </Button>
-      </div>
+      <Empty className="py-24">
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <ShoppingBag />
+          </EmptyMedia>
+          <EmptyTitle>{dict.cart.empty}</EmptyTitle>
+        </EmptyHeader>
+        <EmptyContent>
+          <Button asChild className="h-11 px-6 text-base">
+            <Link href={`/${locale}`}>{dict.common.shopNow}</Link>
+          </Button>
+        </EmptyContent>
+      </Empty>
     );
   }
 
   return (
-    <div className="grid gap-8 md:grid-cols-3">
-      <div className="md:col-span-2">
-        <h1 className="mb-4 text-2xl font-bold">{dict.cart.title}</h1>
-        {lines.map((l) => (
-          <CartLineItem key={l.variantId} line={l} locale={locale} dict={dict}
-            onQty={(id, q) => (q < 1 ? handleRemove(id) : updateQty(id, q))}
-            onRemove={handleRemove} />
-        ))}
+    <div className="space-y-8">
+      <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">{dict.cart.title}</h1>
+      <div className="grid gap-10 md:grid-cols-3 md:gap-12">
+        <div className="md:col-span-2">
+          {lines.map((l) => (
+            <CartLineItem key={l.variantId} line={l} locale={locale} dict={dict}
+              onQty={(id, q) => (q < 1 ? handleRemove(id) : updateQty(id, q))}
+              onRemove={handleRemove} />
+          ))}
+        </div>
+        <OrderSummary subtotal={subtotal} currency={currency} locale={locale} dict={dict} ctaHref={`/${locale}/checkout`} ctaLabel={dict.cart.checkout} />
       </div>
-      <OrderSummary subtotal={subtotal} currency={currency} locale={locale} dict={dict} ctaHref={`/${locale}/checkout`} ctaLabel={dict.cart.checkout} />
     </div>
   );
 }

--- a/app/[locale]/checkout/page.tsx
+++ b/app/[locale]/checkout/page.tsx
@@ -10,6 +10,8 @@ import { checkoutSchema, type CheckoutForm } from '@/lib/checkout/schema';
 import { OrderSummary } from '@/components/commerce/order-summary';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Field, FieldError, FieldGroup, FieldLabel } from '@/components/ui/field';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { cartLinesToGa4Items } from '@/lib/analytics/events';
 
@@ -50,44 +52,50 @@ export default function CheckoutPage({ params }: { params: Promise<{ locale: str
   };
 
   return (
-    <div className="grid gap-8 md:grid-cols-3">
-      <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4 md:col-span-2">
-        <h1 className="text-2xl font-bold">{dict.checkout.title}</h1>
+    <div className="grid gap-10 md:grid-cols-3 md:gap-12">
+      <form onSubmit={handleSubmit(onSubmit)} noValidate className="md:col-span-2">
+        <div className="flex flex-col gap-8">
+          <h1 className="text-3xl font-semibold tracking-tight">{dict.checkout.title}</h1>
 
-        {isSubmitted && erroredFields.length > 0 ? (
-          <div role="alert" className="rounded-lg border border-destructive/40 bg-destructive/10 p-4 text-sm">
-            <p className="font-medium text-destructive">{dict.checkout.errors.summary}</p>
-            <ul className="mt-2 list-disc space-y-1 pl-5">
-              {erroredFields.map((f) => (
-                <li key={f.name}>
-                  <a href={`#${f.name}`} className="text-destructive underline">{f.label}</a>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
+          {isSubmitted && erroredFields.length > 0 ? (
+            <Alert variant="destructive" className="border-destructive/40">
+              <AlertTitle>{dict.checkout.errors.summary}</AlertTitle>
+              <AlertDescription>
+                <ul className="flex list-disc flex-col gap-1 pl-4">
+                  {erroredFields.map((f) => (
+                    <li key={f.name}>
+                      <a href={`#${f.name}`} className="underline underline-offset-4">{f.label}</a>
+                    </li>
+                  ))}
+                </ul>
+              </AlertDescription>
+            </Alert>
+          ) : null}
 
-        {fields.map((f) => {
-          const hasError = Boolean(errors[f.name]);
-          return (
-            <div key={f.name} className="space-y-1.5">
-              <label htmlFor={f.name} className="text-sm font-medium">{f.label}</label>
-              <Input
-                id={f.name}
-                type={f.type}
-                autoComplete={f.autoComplete}
-                aria-invalid={hasError}
-                aria-describedby={hasError ? `${f.name}-error` : undefined}
-                className="h-11"
-                {...register(f.name)}
-              />
-              {hasError ? <p id={`${f.name}-error`} className="text-xs text-destructive">{f.message}</p> : null}
-            </div>
-          );
-        })}
+          <FieldGroup>
+            {fields.map((f) => {
+              const hasError = Boolean(errors[f.name]);
+              return (
+                <Field key={f.name} data-invalid={hasError || undefined}>
+                  <FieldLabel htmlFor={f.name}>{f.label}</FieldLabel>
+                  <Input
+                    id={f.name}
+                    type={f.type}
+                    autoComplete={f.autoComplete}
+                    aria-invalid={hasError}
+                    aria-describedby={hasError ? `${f.name}-error` : undefined}
+                    className="h-11"
+                    {...register(f.name)}
+                  />
+                  {hasError ? <FieldError id={`${f.name}-error`}>{f.message}</FieldError> : null}
+                </Field>
+              );
+            })}
+          </FieldGroup>
 
-        <p className="text-sm text-muted-foreground">{dict.checkout.payNote}</p>
-        <Button type="submit" className="h-11 w-full text-base">{dict.checkout.placeOrder}</Button>
+          <p className="text-sm text-muted-foreground">{dict.checkout.payNote}</p>
+          <Button type="submit" className="h-12 w-full text-base">{dict.checkout.placeOrder}</Button>
+        </div>
       </form>
       <OrderSummary subtotal={subtotal} currency={currency} locale={locale} dict={dict} />
     </div>

--- a/app/[locale]/checkout/success/page.tsx
+++ b/app/[locale]/checkout/success/page.tsx
@@ -3,6 +3,7 @@ import { use, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import { isLocale, type Locale, defaultLocale } from '@/lib/i18n/config';
 import { getDictionary } from '@/lib/i18n/dictionaries';
 import { useCart } from '@/features/cart/use-cart';
@@ -34,15 +35,21 @@ export default function SuccessPage({ params }: { params: Promise<{ locale: stri
   }, []);
 
   return (
-    <div className="flex flex-col items-center py-16 text-center">
-      <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
-        <CheckCircle2 className="h-8 w-8 text-primary" />
-      </div>
-      <h1 className="mb-2 text-2xl font-bold">{dict.checkout.success}</h1>
-      {orderId ? <p className="text-muted-foreground">{dict.checkout.orderId}: {orderId}</p> : null}
-      <Button asChild className="mt-6 h-11 px-6 text-base">
-        <Link href={`/${locale}`}>{dict.common.shopNow}</Link>
-      </Button>
-    </div>
+    <Empty className="py-24">
+      <EmptyHeader>
+        <EmptyMedia variant="icon" className="bg-primary/10 text-primary">
+          <CheckCircle2 />
+        </EmptyMedia>
+        <EmptyTitle>{dict.checkout.success}</EmptyTitle>
+        {orderId ? (
+          <EmptyDescription>{dict.checkout.orderId}: {orderId}</EmptyDescription>
+        ) : null}
+      </EmptyHeader>
+      <EmptyContent>
+        <Button asChild className="h-11 px-6 text-base">
+          <Link href={`/${locale}`}>{dict.common.shopNow}</Link>
+        </Button>
+      </EmptyContent>
+    </Empty>
   );
 }

--- a/app/[locale]/collection/[slug]/page.tsx
+++ b/app/[locale]/collection/[slug]/page.tsx
@@ -3,8 +3,10 @@ import { isLocale, type Locale } from '@/lib/i18n/config';
 import { getDictionary, type Dictionary } from '@/lib/i18n/dictionaries';
 import { productRepository } from '@/lib/data';
 import type { ProductQuery } from '@/lib/data';
+import { SearchX } from 'lucide-react';
 import { ProductGrid } from '@/components/commerce/product-grid';
 import { CollectionFilters } from '@/components/commerce/collection-filters';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 import type { LensType, ReplacementSchedule } from '@/lib/types';
 
 function resolveTitle(dict: Dictionary, key: string): string {
@@ -48,16 +50,26 @@ export default async function CollectionPage({
   const products = filtered.filter((p) => ids.has(p.id));
 
   return (
-    <div>
-      <h1 className="mb-4 text-2xl font-bold">{resolveTitle(dict, collection.title)}</h1>
-      <CollectionFilters dict={dict} />
+    <div className="space-y-8">
+      <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">{resolveTitle(dict, collection.title)}</h1>
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <CollectionFilters dict={dict} />
+        {products.length > 0 ? (
+          <p className="text-sm text-muted-foreground">{products.length} {dict.collection.productsLabel}</p>
+        ) : null}
+      </div>
       {products.length === 0 ? (
-        <p className="py-16 text-center text-muted-foreground">{dict.collection.noResults}</p>
+        <Empty className="rounded-xl border py-16">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <SearchX />
+            </EmptyMedia>
+            <EmptyTitle>{dict.collection.noResults}</EmptyTitle>
+            <EmptyDescription>{dict.filters.clear}</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       ) : (
-        <>
-          <p className="mb-4 text-sm text-muted-foreground">{products.length} {dict.collection.productsLabel}</p>
-          <ProductGrid products={products} locale={l} listId={collection.slug} />
-        </>
+        <ProductGrid products={products} locale={l} listId={collection.slug} />
       )}
     </div>
   );

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -21,7 +21,7 @@ export default async function LocaleLayout({
     <>
       <AnnouncementBar text={dict.announcement.freeShipping} />
       <Header locale={locale as Locale} dict={dict} />
-      <main className="mx-auto max-w-7xl px-4 py-8">{children}</main>
+      <main className="mx-auto w-full max-w-7xl px-4 py-10 md:py-14">{children}</main>
       <Footer locale={locale as Locale} dict={dict} />
     </>
   );

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -18,8 +18,9 @@ export default async function HomePage({ params }: { params: Promise<{ locale: s
   const coloredProducts = colored ? await productRepository.getProductsByIds(colored.productIds) : [];
 
   return (
-    <div className="space-y-12">
+    <div className="space-y-16 md:space-y-24">
       <HeroCarousel
+        ctaLabel={dict.common.shopNow}
         slides={[
           { image: '/images/hero-1.jpg', href: `/${l}/collection/new-arrivals`, alt: dict.collection.newArrivals },
           { image: '/images/hero-2.jpg', href: `/${l}/collection/sale`, alt: dict.collection.sale },

--- a/app/[locale]/product/[slug]/page.tsx
+++ b/app/[locale]/product/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { isLocale, type Locale } from '@/lib/i18n/config';
 import { getDictionary } from '@/lib/i18n/dictionaries';
@@ -8,6 +9,9 @@ import { SpecTable } from '@/components/commerce/spec-table';
 import { ReviewsList } from '@/components/commerce/reviews-list';
 import { CollectionCarousel } from '@/components/commerce/collection-carousel';
 import { RatingStars } from '@/components/commerce/rating-stars';
+import {
+  Breadcrumb, BreadcrumbItem, BreadcrumbLink, BreadcrumbList, BreadcrumbPage, BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
 
 export default async function ProductPage({ params }: { params: Promise<{ locale: string; slug: string }> }) {
   const { locale, slug } = await params;
@@ -22,22 +26,40 @@ export default async function ProductPage({ params }: { params: Promise<{ locale
   const reviews = await productRepository.getReviews(product.id);
 
   return (
-    <div className="space-y-16">
-      <div className="grid gap-8 md:grid-cols-2">
-        <ProductGallery images={product.images} alt={product.name} />
-        <div className="space-y-4">
-          <h1 className="text-3xl font-bold">{product.name}</h1>
-          <div className="flex items-center gap-2">
-            <RatingStars rating={product.rating} />
-            <span className="text-sm text-muted-foreground">({product.reviewCount})</span>
+    <div className="space-y-16 md:space-y-24">
+      <div className="space-y-8">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link href={`/${l}`}>Vivimoon</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{product.name}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
+        <div className="grid gap-10 md:grid-cols-2 lg:gap-16">
+          <ProductGallery images={product.images} alt={product.name} />
+          <div className="flex flex-col gap-5">
+            <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">{product.name}</h1>
+            <div className="flex items-center gap-2">
+              <RatingStars rating={product.rating} />
+              <span className="text-sm text-muted-foreground">
+                {product.rating.toFixed(1)} · {product.reviewCount}
+              </span>
+            </div>
+            <p className="max-w-prose leading-relaxed text-muted-foreground">{product.description}</p>
+            <AddToCart product={product} locale={l} dict={dict} />
           </div>
-          <p className="leading-relaxed text-muted-foreground">{product.description}</p>
-          <AddToCart product={product} locale={l} dict={dict} />
         </div>
       </div>
 
-      <section>
-        <h2 className="mb-4 text-xl font-semibold">{dict.pdp.specs}</h2>
+      <section className="space-y-6">
+        <h2 className="text-2xl font-semibold tracking-tight">{dict.pdp.specs}</h2>
         <SpecTable specs={product.specs} dict={dict} />
       </section>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -7,9 +7,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-inter);
+  --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-fraunces);
+  --font-heading: var(--font-geist-sans);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -49,25 +49,25 @@
 }
 
 :root {
-  /* Soft Rosé / K-beauty — warm white, dusty-rose accent, blush neutrals, plum-ink text */
-  --background: oklch(0.993 0.004 40);
-  --foreground: oklch(0.25 0.02 350);
+  /* Clean luxury — true-neutral base, single deep-rose accent (locked), ink text */
+  --background: oklch(0.994 0 0);
+  --foreground: oklch(0.16 0 0);
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.25 0.02 350);
+  --card-foreground: oklch(0.16 0 0);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.25 0.02 350);
-  --primary: oklch(0.58 0.14 8);
-  --primary-foreground: oklch(0.99 0.003 40);
-  --secondary: oklch(0.955 0.012 350);
-  --secondary-foreground: oklch(0.3 0.02 350);
-  --muted: oklch(0.94 0.012 350);
-  --muted-foreground: oklch(0.48 0.03 350);
-  --accent: oklch(0.955 0.014 350);
-  --accent-foreground: oklch(0.3 0.02 350);
+  --popover-foreground: oklch(0.16 0 0);
+  --primary: oklch(0.52 0.16 6);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.968 0 0);
+  --secondary-foreground: oklch(0.22 0 0);
+  --muted: oklch(0.968 0 0);
+  --muted-foreground: oklch(0.46 0 0);
+  --accent: oklch(0.968 0 0);
+  --accent-foreground: oklch(0.22 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.9 0.014 350);
-  --input: oklch(0.9 0.014 350);
-  --ring: oklch(0.58 0.14 8);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.52 0.16 6);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -85,24 +85,24 @@
 }
 
 .dark {
-  --background: oklch(0.19 0.014 340);
-  --foreground: oklch(0.97 0.005 350);
-  --card: oklch(0.24 0.016 340);
-  --card-foreground: oklch(0.97 0.005 350);
-  --popover: oklch(0.24 0.016 340);
-  --popover-foreground: oklch(0.97 0.005 350);
-  --primary: oklch(0.72 0.13 8);
-  --primary-foreground: oklch(0.19 0.014 340);
-  --secondary: oklch(0.28 0.014 340);
-  --secondary-foreground: oklch(0.97 0.005 350);
-  --muted: oklch(0.28 0.014 340);
-  --muted-foreground: oklch(0.74 0.02 345);
-  --accent: oklch(0.28 0.014 340);
-  --accent-foreground: oklch(0.97 0.005 350);
+  --background: oklch(0.16 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.66 0.16 6);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.26 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.26 0 0);
+  --muted-foreground: oklch(0.712 0 0);
+  --accent: oklch(0.26 0 0);
+  --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --border: oklch(1 0 0 / 12%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.72 0.13 8);
+  --ring: oklch(0.66 0.16 6);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
@@ -129,6 +129,10 @@
     @apply font-sans;
   }
   h1, h2, h3 {
-    @apply font-heading;
+    @apply font-heading tracking-tight;
+    text-wrap: balance;
+  }
+  html {
+    scroll-behavior: smooth;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,17 +1,11 @@
 import type { Metadata } from "next";
-import { Inter, Fraunces, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { CartProvider } from "@/features/cart/cart-context";
 import "./globals.css";
 
-const inter = Inter({
-  variable: "--font-inter",
-  subsets: ["latin"],
-  display: "swap",
-});
-
-const fraunces = Fraunces({
-  variable: "--font-fraunces",
+const geistSans = Geist({
+  variable: "--font-geist-sans",
   subsets: ["latin"],
   display: "swap",
 });
@@ -19,6 +13,7 @@ const fraunces = Fraunces({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -30,7 +25,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html
       lang="en"
-      className={`${inter.variable} ${fraunces.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <CartProvider>

--- a/components/commerce/add-to-cart.tsx
+++ b/components/commerce/add-to-cart.tsx
@@ -3,10 +3,12 @@ import { useEffect, useState } from 'react';
 import type { Product, Variant } from '@/lib/types';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
+import { Truck } from 'lucide-react';
 import { VariantSelector } from './variant-selector';
 import { PriceTag } from './price-tag';
 import { QuantityStepper } from './quantity-stepper';
 import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
 import { useCart } from '@/features/cart/use-cart';
 import { useAnalytics } from '@/lib/analytics/use-analytics';
 import { toGa4Items } from '@/lib/analytics/events';
@@ -32,10 +34,11 @@ export function AddToCart({ product, locale, dict }: { product: Product; locale:
   };
 
   return (
-    <div className="space-y-6">
-      <PriceTag price={variant.price} compareAtPrice={variant.compareAtPrice} currency={variant.currency} locale={locale} className="text-2xl" />
+    <div className="flex flex-col gap-6">
+      <PriceTag price={variant.price} compareAtPrice={variant.compareAtPrice} currency={variant.currency} locale={locale} className="text-3xl" />
+      <Separator />
       <VariantSelector product={product} dict={dict} onVariantChange={setVariant} />
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-4">
         <span className="text-sm font-medium">{dict.pdp.quantity}</span>
         <QuantityStepper
           value={qty}
@@ -44,7 +47,11 @@ export function AddToCart({ product, locale, dict }: { product: Product; locale:
           increaseLabel={dict.common.increaseQty}
         />
       </div>
-      <Button onClick={onAdd} className="h-11 w-full text-base">{dict.common.addToCart}</Button>
+      <Button onClick={onAdd} className="h-12 w-full text-base">{dict.common.addToCart}</Button>
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Truck className="size-4" />
+        {dict.pdp.freeship}
+      </div>
     </div>
   );
 }

--- a/components/commerce/cart-line-item.tsx
+++ b/components/commerce/cart-line-item.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { X } from 'lucide-react';
 import type { CartLine } from '@/features/cart/cart.types';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
@@ -13,24 +14,37 @@ export function CartLineItem({
   onRemove: (variantId: string) => void;
 }) {
   return (
-    <div className="flex items-center gap-4 border-b py-4">
-      <div className="relative h-20 w-20 overflow-hidden rounded bg-muted">
-        {line.image ? <Image src={line.image} alt={line.name} fill className="object-cover" sizes="80px" /> : null}
+    <div className="flex gap-4 border-b py-6 first:pt-0">
+      <div className="relative size-24 shrink-0 overflow-hidden rounded-lg bg-muted">
+        {line.image ? <Image src={line.image} alt={line.name} fill className="object-cover" sizes="96px" /> : null}
       </div>
-      <div className="flex-1">
-        <p className="font-medium">{line.name}</p>
-        <p className="text-sm text-muted-foreground">{line.packSize}{line.color ? ` · ${line.color}` : ''}</p>
-        <QuantityStepper
-          className="mt-2"
-          value={line.quantity}
-          onChange={(next) => onQty(line.variantId, next)}
-          decreaseLabel={dict.common.decreaseQty}
-          increaseLabel={dict.common.increaseQty}
-        />
-      </div>
-      <div className="text-right">
-        <p className="font-semibold">{formatPrice(line.unitPrice * line.quantity, line.currency, locale)}</p>
-        <button onClick={() => onRemove(line.variantId)} className="text-sm text-muted-foreground underline">{dict.cart.remove}</button>
+      <div className="flex flex-1 flex-col">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <p className="font-medium leading-snug">{line.name}</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {line.packSize}{line.color ? ` · ${line.color}` : ''}
+            </p>
+          </div>
+          <button
+            onClick={() => onRemove(line.variantId)}
+            aria-label={dict.cart.remove}
+            className="-mr-1 flex size-8 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="mt-auto flex items-end justify-between gap-3 pt-4">
+          <QuantityStepper
+            value={line.quantity}
+            onChange={(next) => onQty(line.variantId, next)}
+            decreaseLabel={dict.common.decreaseQty}
+            increaseLabel={dict.common.increaseQty}
+          />
+          <p className="font-semibold tabular-nums">
+            {formatPrice(line.unitPrice * line.quantity, line.currency, locale)}
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/components/commerce/category-grid.tsx
+++ b/components/commerce/category-grid.tsx
@@ -1,15 +1,30 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { ArrowUpRight } from 'lucide-react';
 
 export function CategoryGrid({ items }: { items: { label: string; href: string; image: string }[] }) {
   return (
-    <div className="grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-6">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
       {items.map((it) => (
-        <Link key={it.href} href={it.href} className="group flex flex-col items-center gap-2">
-          <div className="relative aspect-square w-full overflow-hidden rounded-full bg-muted">
-            <Image src={it.image} alt={it.label} fill className="object-cover" sizes="120px" />
+        <Link
+          key={it.href}
+          href={it.href}
+          className="group relative aspect-[4/5] overflow-hidden rounded-2xl bg-muted"
+        >
+          <Image
+            src={it.image}
+            alt={it.label}
+            fill
+            className="object-cover transition-transform duration-500 ease-out group-hover:scale-105"
+            sizes="(max-width:640px) 100vw, 33vw"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
+          <div className="absolute inset-x-0 bottom-0 flex items-center justify-between p-5">
+            <span className="text-lg font-medium tracking-tight text-white">{it.label}</span>
+            <span className="flex size-9 items-center justify-center rounded-full bg-white/15 text-white backdrop-blur-sm transition-colors group-hover:bg-white group-hover:text-black">
+              <ArrowUpRight className="size-4" />
+            </span>
           </div>
-          <span className="text-sm font-medium">{it.label}</span>
         </Link>
       ))}
     </div>

--- a/components/commerce/collection-carousel.tsx
+++ b/components/commerce/collection-carousel.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 import useEmblaCarousel from 'embla-carousel-react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ArrowRight } from 'lucide-react';
 import type { Product } from '@/lib/types';
 import type { Locale } from '@/lib/i18n/config';
 import { ProductCard } from './product-card';
@@ -13,23 +13,43 @@ export function CollectionCarousel({
 }) {
   const [ref, embla] = useEmblaCarousel({ align: 'start', dragFree: true });
   return (
-    <section className="space-y-4">
-      <div className="flex items-center justify-between">
-        <h2 className="text-xl font-semibold">{title}</h2>
-        <Link href={seeMoreHref} className="text-sm hover:underline">{seeMoreLabel}</Link>
-      </div>
-      <div className="relative">
-        <div className="overflow-hidden" ref={ref}>
-          <div className="flex gap-4">
-            {products.map((p) => (
-              <div key={p.id} className="min-w-0 flex-[0_0_60%] sm:flex-[0_0_40%] lg:flex-[0_0_23%]">
-                <ProductCard product={p} locale={locale} />
-              </div>
-            ))}
+    <section className="space-y-6">
+      <div className="flex items-end justify-between gap-4">
+        <h2 className="text-2xl font-semibold tracking-tight md:text-3xl">{title}</h2>
+        <div className="flex items-center gap-2">
+          <Link
+            href={seeMoreHref}
+            className="group inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {seeMoreLabel}
+            <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+          </Link>
+          <div className="hidden items-center gap-1.5 md:flex">
+            <button
+              aria-label="Previous"
+              onClick={() => embla?.scrollPrev()}
+              className="flex size-9 items-center justify-center rounded-full border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+            <button
+              aria-label="Next"
+              onClick={() => embla?.scrollNext()}
+              className="flex size-9 items-center justify-center rounded-full border text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <ChevronRight className="size-4" />
+            </button>
           </div>
         </div>
-        <button aria-label="Previous slide" onClick={() => embla?.scrollPrev()} className="absolute -left-3 top-1/3 flex h-11 w-11 items-center justify-center rounded-full bg-background/90 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background"><ChevronLeft className="h-5 w-5" /></button>
-        <button aria-label="Next slide" onClick={() => embla?.scrollNext()} className="absolute -right-3 top-1/3 flex h-11 w-11 items-center justify-center rounded-full bg-background/90 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background"><ChevronRight className="h-5 w-5" /></button>
+      </div>
+      <div className="overflow-hidden" ref={ref}>
+        <div className="flex gap-5">
+          {products.map((p) => (
+            <div key={p.id} className="min-w-0 flex-[0_0_60%] sm:flex-[0_0_38%] lg:flex-[0_0_23%]">
+              <ProductCard product={p} locale={locale} />
+            </div>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/components/commerce/collection-filters.tsx
+++ b/components/commerce/collection-filters.tsx
@@ -1,37 +1,78 @@
 'use client';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
+import {
+  Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
 
 const TYPES = ['clear', 'colored', 'toric', 'multifocal'];
 const REPLACEMENTS = ['daily', 'biweekly', 'monthly'];
 const SORTS = ['newest', 'price-asc', 'price-desc', 'bestselling'];
+const ALL = 'all';
 
 export function CollectionFilters({ dict }: { dict: Dictionary }) {
   const router = useRouter();
   const pathname = usePathname();
   const params = useSearchParams();
+  const hasFilters = ['type', 'replacement', 'sort'].some((k) => params.get(k));
 
   const setParam = (key: string, value: string) => {
     const next = new URLSearchParams(params.toString());
-    if (value) next.set(key, value); else next.delete(key);
+    if (value && value !== ALL) next.set(key, value);
+    else next.delete(key);
     router.push(`${pathname}?${next.toString()}`);
   };
 
   return (
-    <div className="mb-6 flex flex-wrap gap-3">
-      <select aria-label={dict.filters.type} value={params.get('type') ?? ''} onChange={(e) => setParam('type', e.target.value)} className="rounded border px-2 py-1 text-sm">
-        <option value="">{dict.filters.type}</option>
-        {TYPES.map((t) => <option key={t} value={t}>{dict.filters.types[t as keyof typeof dict.filters.types]}</option>)}
-      </select>
-      <select aria-label={dict.filters.replacement} value={params.get('replacement') ?? ''} onChange={(e) => setParam('replacement', e.target.value)} className="rounded border px-2 py-1 text-sm">
-        <option value="">{dict.filters.replacement}</option>
-        {REPLACEMENTS.map((r) => <option key={r} value={r}>{dict.filters.replacements[r as keyof typeof dict.filters.replacements]}</option>)}
-      </select>
-      <select aria-label={dict.filters.sort} value={params.get('sort') ?? ''} onChange={(e) => setParam('sort', e.target.value)} className="rounded border px-2 py-1 text-sm">
-        <option value="">{dict.filters.sort}</option>
-        {SORTS.map((s) => <option key={s} value={s}>{dict.filters.sorts[s as keyof typeof dict.filters.sorts]}</option>)}
-      </select>
-      <button onClick={() => router.push(pathname)} className="text-sm underline">{dict.filters.clear}</button>
+    <div className="flex flex-wrap items-center gap-2.5">
+      <Select value={params.get('type') ?? ALL} onValueChange={(v) => setParam('type', v)}>
+        <SelectTrigger className="w-40" aria-label={dict.filters.type}>
+          <SelectValue placeholder={dict.filters.type} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value={ALL}>{dict.filters.type}</SelectItem>
+            {TYPES.map((t) => (
+              <SelectItem key={t} value={t}>{dict.filters.types[t as keyof typeof dict.filters.types]}</SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+
+      <Select value={params.get('replacement') ?? ALL} onValueChange={(v) => setParam('replacement', v)}>
+        <SelectTrigger className="w-40" aria-label={dict.filters.replacement}>
+          <SelectValue placeholder={dict.filters.replacement} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value={ALL}>{dict.filters.replacement}</SelectItem>
+            {REPLACEMENTS.map((r) => (
+              <SelectItem key={r} value={r}>{dict.filters.replacements[r as keyof typeof dict.filters.replacements]}</SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+
+      <Select value={params.get('sort') ?? ALL} onValueChange={(v) => setParam('sort', v)}>
+        <SelectTrigger className="w-40" aria-label={dict.filters.sort}>
+          <SelectValue placeholder={dict.filters.sort} />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value={ALL}>{dict.filters.sort}</SelectItem>
+            {SORTS.map((s) => (
+              <SelectItem key={s} value={s}>{dict.filters.sorts[s as keyof typeof dict.filters.sorts]}</SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+
+      {hasFilters ? (
+        <Button variant="ghost" size="sm" onClick={() => router.push(pathname)}>
+          {dict.filters.clear}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/components/commerce/hero-carousel.tsx
+++ b/components/commerce/hero-carousel.tsx
@@ -1,30 +1,85 @@
 'use client';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils/cn';
 
-export function HeroCarousel({ slides }: { slides: { image: string; href: string; alt: string }[] }) {
+type Slide = { image: string; href: string; alt: string };
+
+export function HeroCarousel({ slides, ctaLabel }: { slides: Slide[]; ctaLabel: string }) {
   const [ref, embla] = useEmblaCarousel({ loop: true });
+  const [selected, setSelected] = useState(0);
+
+  const onSelect = useCallback(() => {
+    if (embla) setSelected(embla.selectedScrollSnap());
+  }, [embla]);
+
+  useEffect(() => {
+    if (!embla) return;
+    onSelect();
+    embla.on('select', onSelect);
+    return () => {
+      embla.off('select', onSelect);
+    };
+  }, [embla, onSelect]);
+
   return (
-    <div className="relative">
+    <div className="relative overflow-hidden rounded-2xl">
       <div className="overflow-hidden" ref={ref}>
         <div className="flex">
           {slides.map((s) => (
-            <Link key={s.href} href={s.href} className="relative min-w-0 flex-[0_0_100%]">
-              <div className="relative aspect-[21/9] w-full">
+            <div key={s.href} className="relative min-w-0 flex-[0_0_100%]">
+              <div className="relative aspect-[3/4] w-full sm:aspect-[16/9] lg:aspect-[21/9]">
                 <Image src={s.image} alt={s.alt} fill className="object-cover" priority />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/55 via-black/10 to-transparent" />
+                <div className="absolute inset-0 flex flex-col justify-end gap-4 p-6 md:p-12">
+                  <h2 className="max-w-md text-3xl font-semibold tracking-tight text-white md:text-5xl">
+                    {s.alt}
+                  </h2>
+                  <Link
+                    href={s.href}
+                    className="inline-flex h-11 w-fit items-center rounded-full bg-white px-6 text-sm font-medium text-black transition-transform hover:-translate-y-px"
+                  >
+                    {ctaLabel}
+                  </Link>
+                </div>
               </div>
-            </Link>
+            </div>
           ))}
         </div>
       </div>
-      <button aria-label="Previous slide" onClick={() => embla?.scrollPrev()} className="absolute left-3 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background">
-        <ChevronLeft className="h-5 w-5" />
+
+      <button
+        aria-label="Previous slide"
+        onClick={() => embla?.scrollPrev()}
+        className="absolute left-4 top-1/2 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-background/70 text-foreground shadow-sm backdrop-blur-md transition-colors hover:bg-background"
+      >
+        <ChevronLeft className="size-5" />
       </button>
-      <button aria-label="Next slide" onClick={() => embla?.scrollNext()} className="absolute right-3 top-1/2 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full bg-background/80 text-foreground shadow backdrop-blur-sm transition-colors hover:bg-background">
-        <ChevronRight className="h-5 w-5" />
+      <button
+        aria-label="Next slide"
+        onClick={() => embla?.scrollNext()}
+        className="absolute right-4 top-1/2 flex size-11 -translate-y-1/2 items-center justify-center rounded-full bg-background/70 text-foreground shadow-sm backdrop-blur-md transition-colors hover:bg-background"
+      >
+        <ChevronRight className="size-5" />
       </button>
+
+      <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-2">
+        {slides.map((s, i) => (
+          <button
+            key={s.href}
+            aria-label={`Go to slide ${i + 1}`}
+            aria-current={selected === i}
+            onClick={() => embla?.scrollTo(i)}
+            className={cn(
+              'h-1.5 rounded-full bg-white/60 transition-all',
+              selected === i ? 'w-6 bg-white' : 'w-1.5 hover:bg-white/80',
+            )}
+          />
+        ))}
+      </div>
     </div>
   );
 }

--- a/components/commerce/order-summary.tsx
+++ b/components/commerce/order-summary.tsx
@@ -4,23 +4,42 @@ import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
 import { formatPrice } from '@/lib/utils/format';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
 
 export function OrderSummary({
   subtotal, currency, locale, dict, ctaHref, ctaLabel,
 }: {
   subtotal: number; currency: Currency; locale: Locale; dict: Dictionary; ctaHref?: string; ctaLabel?: string;
 }) {
+  const price = (n: number) => formatPrice(n, currency, locale);
   return (
-    <div className="space-y-4 rounded-lg border p-6">
-      <div className="flex justify-between">
-        <span>{dict.cart.subtotal}</span>
-        <span className="font-semibold">{formatPrice(subtotal, currency, locale)}</span>
-      </div>
+    <Card className="h-fit md:sticky md:top-24">
+      <CardHeader>
+        <CardTitle>{dict.cart.orderSummary}</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3 text-sm">
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">{dict.cart.subtotal}</span>
+          <span className="tabular-nums">{price(subtotal)}</span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-muted-foreground">{dict.cart.shipping}</span>
+          <span>{dict.cart.free}</span>
+        </div>
+        <Separator />
+        <div className="flex items-baseline justify-between">
+          <span className="font-medium">{dict.cart.total}</span>
+          <span className="text-lg font-semibold tabular-nums">{price(subtotal)}</span>
+        </div>
+      </CardContent>
       {ctaHref && ctaLabel ? (
-        <Button asChild className="h-11 w-full text-base">
-          <Link href={ctaHref}>{ctaLabel}</Link>
-        </Button>
+        <CardFooter>
+          <Button asChild className="h-12 w-full text-base">
+            <Link href={ctaHref}>{ctaLabel}</Link>
+          </Button>
+        </CardFooter>
       ) : null}
-    </div>
+    </Card>
   );
 }

--- a/components/commerce/price-tag.tsx
+++ b/components/commerce/price-tag.tsx
@@ -8,16 +8,19 @@ export function PriceTag({
 }: {
   price: number; currency: Currency; locale: Locale; compareAtPrice?: number; className?: string;
 }) {
+  const onSale = Boolean(compareAtPrice);
   const discount = compareAtPrice ? Math.round((1 - price / compareAtPrice) * 100) : 0;
   return (
-    <div className={cn('flex items-center gap-2', className)}>
-      <span className="font-semibold">{formatPrice(price, currency, locale)}</span>
+    <div className={cn('flex items-baseline gap-2', className)}>
+      <span className={cn('font-semibold tabular-nums', onSale && 'text-primary')}>
+        {formatPrice(price, currency, locale)}
+      </span>
       {compareAtPrice ? (
         <>
-          <span className="text-sm text-muted-foreground line-through">
+          <span className="text-sm tabular-nums text-muted-foreground line-through">
             {formatPrice(compareAtPrice, currency, locale)}
           </span>
-          <span className="text-xs font-medium text-destructive">-{discount}%</span>
+          <span className="text-xs font-medium text-primary">-{discount}%</span>
         </>
       ) : null}
     </div>

--- a/components/commerce/product-card.tsx
+++ b/components/commerce/product-card.tsx
@@ -1,11 +1,8 @@
-'use client';
 import Link from 'next/link';
 import Image from 'next/image';
-import { useState } from 'react';
 import type { Product } from '@/lib/types';
 import type { Locale } from '@/lib/i18n/config';
 import { PriceTag } from './price-tag';
-import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils/cn';
 
 function minVariant(product: Product) {
@@ -17,35 +14,74 @@ export function ProductCard({
 }: {
   product: Product; locale: Locale; onSelect?: () => void;
 }) {
-  const [hover, setHover] = useState(false);
   const v = minVariant(product);
+  const primary = product.images[0];
   const secondary = product.images[1] ?? product.images[0];
-  const src = hover ? secondary : product.images[0];
-  const colors = product.variants.filter((x) => x.color);
+  const colors = Array.from(
+    new Map(product.variants.filter((x) => x.color).map((c) => [c.color, c])).values(),
+  );
 
   return (
-    <div className="group flex flex-col gap-2" onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
+    <div className="group flex flex-col gap-3">
       <Link
         href={`/${locale}/product/${product.slug}`}
         onClick={onSelect}
-        className="relative block aspect-square overflow-hidden rounded-md bg-muted"
+        className="relative block aspect-square overflow-hidden rounded-lg bg-muted"
         aria-hidden="true"
         tabIndex={-1}
       >
-        {src ? <Image src={src} alt={product.name} fill className="object-cover" sizes="(max-width:768px) 50vw, 25vw" /> : null}
-        {product.badges[0] ? <Badge className="absolute left-2 top-2 capitalize">{product.badges[0]}</Badge> : null}
+        {primary ? (
+          <Image
+            src={primary}
+            alt=""
+            fill
+            className="object-cover transition-all duration-500 ease-out group-hover:scale-105 group-hover:opacity-0"
+            sizes="(max-width:768px) 50vw, 25vw"
+          />
+        ) : null}
+        {secondary ? (
+          <Image
+            src={secondary}
+            alt=""
+            fill
+            className="object-cover opacity-0 transition-all duration-500 ease-out group-hover:scale-105 group-hover:opacity-100"
+            sizes="(max-width:768px) 50vw, 25vw"
+          />
+        ) : null}
+        {product.badges[0] ? (
+          <span className="absolute left-3 top-3 rounded-full bg-background/90 px-2.5 py-1 text-[10px] font-medium uppercase tracking-wide text-foreground backdrop-blur-sm">
+            {product.badges[0]}
+          </span>
+        ) : null}
       </Link>
-      {colors.length > 0 ? (
-        <div className="flex gap-1">
-          {Array.from(new Map(colors.map((c) => [c.color, c])).values()).map((c) => (
-            <span key={c.color} title={c.colorLabel} className={cn('h-4 w-4 rounded-full border')} style={{ backgroundColor: c.color }} />
-          ))}
-        </div>
-      ) : null}
-      <Link href={`/${locale}/product/${product.slug}`} onClick={onSelect} className="font-medium hover:underline">
-        {product.name}
-      </Link>
-      <PriceTag price={v.price} compareAtPrice={v.compareAtPrice} currency={v.currency} locale={locale} />
+
+      <div className="flex flex-col gap-2">
+        {colors.length > 0 ? (
+          <div className="flex gap-1.5">
+            {colors.map((c) => (
+              <span
+                key={c.color}
+                title={c.colorLabel}
+                className={cn('size-3.5 rounded-full ring-1 ring-border ring-offset-1 ring-offset-background')}
+                style={{ backgroundColor: c.color }}
+              />
+            ))}
+          </div>
+        ) : null}
+        <Link
+          href={`/${locale}/product/${product.slug}`}
+          onClick={onSelect}
+          className="text-sm font-medium leading-snug text-foreground transition-colors hover:text-primary"
+        >
+          {product.name}
+        </Link>
+        <PriceTag
+          price={v.price}
+          compareAtPrice={v.compareAtPrice}
+          currency={v.currency}
+          locale={locale}
+        />
+      </div>
     </div>
   );
 }

--- a/components/commerce/product-gallery.tsx
+++ b/components/commerce/product-gallery.tsx
@@ -9,7 +9,7 @@ export function ProductGallery({ images, alt }: { images: string[]; alt: string 
     <div className="flex flex-col-reverse gap-4 md:flex-row">
       <div className="flex gap-2 overflow-x-auto md:flex-col md:overflow-visible">
         {images.map((src, i) => (
-          <button key={src} aria-label={`${alt} ${i + 1}`} aria-current={active === i} onClick={() => setActive(i)} className={cn('relative h-16 w-16 shrink-0 overflow-hidden rounded border', active === i && 'ring-2 ring-primary')}>
+          <button key={src} aria-label={`${alt} ${i + 1}`} aria-current={active === i} onClick={() => setActive(i)} className={cn('relative size-16 shrink-0 overflow-hidden rounded-lg border transition-shadow', active === i && 'ring-2 ring-primary ring-offset-2 ring-offset-background')}>
             <Image src={src} alt={`${alt} ${i + 1}`} fill className="object-cover" sizes="64px" />
           </button>
         ))}

--- a/components/commerce/product-grid.tsx
+++ b/components/commerce/product-grid.tsx
@@ -13,7 +13,7 @@ export function ProductGrid({ products, locale, listId }: { products: Product[];
   }, [listId, products, track]);
 
   return (
-    <div className="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-x-5 gap-y-10 md:grid-cols-3 lg:grid-cols-4 lg:gap-x-6">
       {products.map((p) => (
         <ProductCard
           key={p.id}

--- a/components/commerce/rating-stars.tsx
+++ b/components/commerce/rating-stars.tsx
@@ -7,7 +7,7 @@ export function RatingStars({ rating, className }: { rating: number; className?:
       {[1, 2, 3, 4, 5].map((i) => (
         <Star
           key={i}
-          className={cn('h-4 w-4', i <= Math.round(rating) ? 'fill-yellow-400 text-yellow-400' : 'text-muted-foreground')}
+          className={cn('size-3.5', i <= Math.round(rating) ? 'fill-foreground text-foreground' : 'fill-transparent text-muted-foreground/40')}
         />
       ))}
     </div>

--- a/components/commerce/reviews-list.tsx
+++ b/components/commerce/reviews-list.tsx
@@ -1,25 +1,50 @@
+import { MessageSquare } from 'lucide-react';
 import type { Review } from '@/lib/types';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
 import { RatingStars } from './rating-stars';
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
 
 export function ReviewsList({ reviews, dict }: { reviews: Review[]; dict: Dictionary }) {
+  const average =
+    reviews.length > 0 ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length : 0;
+
   return (
-    <section className="space-y-4">
-      <h2 className="text-xl font-semibold">{dict.pdp.reviews}</h2>
-      {reviews.length === 0 ? (
-        <p className="text-sm text-muted-foreground">{dict.pdp.noReviews}</p>
-      ) : (
-        reviews.map((r) => (
-          <div key={r.id} className="border-b pb-4">
-            <div className="flex items-center gap-2">
-              <RatingStars rating={r.rating} />
-              <span className="text-sm font-medium">{r.author}</span>
-              <span className="text-xs text-muted-foreground">{r.createdAt}</span>
-            </div>
-            <p className="mt-1 font-medium">{r.title}</p>
-            <p className="text-sm text-muted-foreground">{r.body}</p>
+    <section className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-2xl font-semibold tracking-tight">{dict.pdp.reviews}</h2>
+        {reviews.length > 0 ? (
+          <div className="flex items-center gap-2">
+            <RatingStars rating={average} />
+            <span className="text-sm text-muted-foreground">
+              {average.toFixed(1)} · {reviews.length}
+            </span>
           </div>
-        ))
+        ) : null}
+      </div>
+
+      {reviews.length === 0 ? (
+        <Empty className="rounded-xl border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <MessageSquare />
+            </EmptyMedia>
+            <EmptyTitle>{dict.pdp.noReviews}</EmptyTitle>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {reviews.map((r) => (
+            <article key={r.id} className="rounded-xl border p-5">
+              <div className="flex items-center justify-between gap-2">
+                <RatingStars rating={r.rating} />
+                <span className="text-xs text-muted-foreground">{r.createdAt}</span>
+              </div>
+              <p className="mt-3 font-medium">{r.title}</p>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{r.body}</p>
+              <p className="mt-4 text-xs font-medium text-foreground">{r.author}</p>
+            </article>
+          ))}
+        </div>
       )}
     </section>
   );

--- a/components/commerce/spec-table.tsx
+++ b/components/commerce/spec-table.tsx
@@ -11,15 +11,13 @@ export function SpecTable({ specs, dict }: { specs: ProductSpecs; dict: Dictiona
     [dict.pdp.manufacturer, specs.manufacturer],
   ];
   return (
-    <table className="w-full text-sm">
-      <tbody>
-        {rows.map(([k, v]) => (
-          <tr key={k} className="border-b">
-            <th scope="row" className="py-2 text-left font-medium text-muted-foreground">{k}</th>
-            <td className="py-2 text-right">{v}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
+    <dl className="grid grid-cols-2 gap-px overflow-hidden rounded-xl border bg-border md:grid-cols-3">
+      {rows.map(([k, v]) => (
+        <div key={k} className="flex flex-col gap-1.5 bg-background p-5">
+          <dt className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{k}</dt>
+          <dd className="text-sm font-medium text-foreground">{v}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }

--- a/components/commerce/variant-selector.tsx
+++ b/components/commerce/variant-selector.tsx
@@ -26,15 +26,19 @@ export function VariantSelector({
     <div className="space-y-4">
       {colors.length > 0 ? (
         <div>
-          <p className="mb-2 text-sm font-medium">{dict.pdp.color}</p>
-          <div className="flex gap-2">
+          <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">{dict.pdp.color}</p>
+          <div className="flex gap-2.5">
             {colors.map((c) => (
               <button
                 key={c.color}
                 aria-label={c.colorLabel}
+                aria-pressed={color === c.color}
                 title={c.colorLabel}
                 onClick={() => { setColor(c.color); const first = product.variants.find((v) => v.color === c.color); if (first) setVariantId(first.id); }}
-                className={cn('h-8 w-8 rounded-full border-2', color === c.color ? 'border-primary' : 'border-transparent')}
+                className={cn(
+                  'size-8 rounded-full ring-offset-2 ring-offset-background transition-shadow',
+                  color === c.color ? 'ring-2 ring-primary' : 'ring-1 ring-border hover:ring-foreground/30',
+                )}
                 style={{ backgroundColor: c.color }}
               />
             ))}
@@ -42,13 +46,19 @@ export function VariantSelector({
         </div>
       ) : null}
       <div>
-        <p className="mb-2 text-sm font-medium">{dict.pdp.packSize}</p>
+        <p className="mb-3 text-xs font-medium uppercase tracking-wide text-muted-foreground">{dict.pdp.packSize}</p>
         <div className="flex flex-wrap gap-2">
           {packs.map((v) => (
             <button
               key={v.id}
+              aria-pressed={variantId === v.id}
               onClick={() => setVariantId(v.id)}
-              className={cn('rounded border px-4 py-2 text-sm', variantId === v.id ? 'border-primary bg-primary/10' : 'border-input')}
+              className={cn(
+                'min-h-11 rounded-lg border px-4 text-sm font-medium transition-colors',
+                variantId === v.id
+                  ? 'border-primary bg-primary/5 text-foreground'
+                  : 'border-input text-muted-foreground hover:border-foreground/30 hover:text-foreground',
+              )}
             >
               {v.packSize}
             </button>

--- a/components/layout/announcement-bar.tsx
+++ b/components/layout/announcement-bar.tsx
@@ -1,3 +1,9 @@
 export function AnnouncementBar({ text }: { text: string }) {
-  return <div className="bg-primary py-2 text-center text-sm text-primary-foreground">{text}</div>;
+  return (
+    <div className="bg-foreground text-background">
+      <p className="mx-auto max-w-7xl px-4 py-2.5 text-center text-xs font-medium tracking-wide">
+        {text}
+      </p>
+    </div>
+  );
 }

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -1,32 +1,61 @@
 import Link from 'next/link';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
+import { Separator } from '@/components/ui/separator';
 
 export function Footer({ locale, dict }: { locale: Locale; dict: Dictionary }) {
+  const policyLinks = [
+    { label: dict.footer.shipping, href: `/${locale}` },
+    { label: dict.footer.returns, href: `/${locale}` },
+    { label: dict.footer.privacy, href: `/${locale}` },
+  ];
+
   return (
-    <footer className="mt-16 border-t bg-muted/30">
-      <div className="mx-auto grid max-w-7xl gap-8 px-4 py-12 md:grid-cols-3">
-        <div>
-          <h3 className="mb-3 font-semibold">{dict.footer.about}</h3>
-          <p className="text-sm text-muted-foreground">{dict.footer.tagline}</p>
+    <footer className="mt-24 border-t">
+      <div className="mx-auto max-w-7xl px-4 py-16">
+        <div className="grid gap-12 md:grid-cols-2 md:gap-8">
+          <div className="max-w-sm">
+            <p className="text-2xl font-semibold tracking-[0.15em] uppercase">Vivimoon</p>
+            <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+              {dict.footer.tagline}
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-8 sm:justify-items-end">
+            <nav aria-label={dict.footer.policies} className="flex flex-col gap-3">
+              <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                {dict.footer.policies}
+              </p>
+              {policyLinks.map((l) => (
+                <Link
+                  key={l.label}
+                  href={l.href}
+                  className="text-sm text-foreground/80 transition-colors hover:text-foreground"
+                >
+                  {l.label}
+                </Link>
+              ))}
+            </nav>
+            <div className="flex flex-col gap-3">
+              <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                {dict.footer.customerCare}
+              </p>
+              <a
+                href="mailto:hello@vivimoon.com"
+                className="text-sm text-foreground/80 transition-colors hover:text-foreground"
+              >
+                hello@vivimoon.com
+              </a>
+              <span className="text-sm text-muted-foreground">
+                {dict.footer.hotline}: 1900 0000
+              </span>
+            </div>
+          </div>
         </div>
-        <div>
-          <h3 className="mb-3 font-semibold">{dict.footer.policies}</h3>
-          <ul className="space-y-1 text-sm text-muted-foreground">
-            <li><Link href={`/${locale}`}>{dict.footer.shipping}</Link></li>
-            <li><Link href={`/${locale}`}>{dict.footer.returns}</Link></li>
-            <li><Link href={`/${locale}`}>{dict.footer.privacy}</Link></li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="mb-3 font-semibold">{dict.footer.customerCare}</h3>
-          <ul className="space-y-1 text-sm text-muted-foreground">
-            <li>hello@vivimoon.com</li>
-            <li>{dict.footer.hotline}: 1900 0000</li>
-          </ul>
-        </div>
+
+        <Separator className="my-10" />
+
+        <p className="text-xs text-muted-foreground">{dict.footer.rights}</p>
       </div>
-      <div className="border-t py-4 text-center text-xs text-muted-foreground">{dict.footer.rights}</div>
     </footer>
   );
 }

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,6 +1,6 @@
 'use client';
 import Link from 'next/link';
-import { ShoppingCart, User, Search } from 'lucide-react';
+import { ShoppingBag, User, Search } from 'lucide-react';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
 import { MegaNav } from './mega-nav';
@@ -11,24 +11,44 @@ import { useCart } from '@/features/cart/use-cart';
 export function Header({ locale, dict }: { locale: Locale; dict: Dictionary }) {
   const { count } = useCart();
   return (
-    <header className="border-b">
-      <div className="mx-auto flex max-w-7xl items-center gap-4 px-4 py-4 md:gap-6">
+    <header className="sticky top-0 z-40 border-b bg-background/80 backdrop-blur-md">
+      <div className="mx-auto flex max-w-7xl items-center gap-4 px-4 py-3.5 md:gap-8">
         <MobileNav locale={locale} dict={dict} />
-        <Link href={`/${locale}`} className="font-heading text-xl font-bold">Vivimoon</Link>
+        <Link
+          href={`/${locale}`}
+          className="text-lg font-semibold tracking-[0.2em] uppercase"
+        >
+          Vivimoon
+        </Link>
         <MegaNav locale={locale} dict={dict} />
-        <div className="ml-auto flex items-center gap-1 md:gap-4">
-          <div className="hidden items-center gap-2 rounded border px-2 md:flex">
-            <Search className="h-4 w-4 text-muted-foreground" />
-            <input aria-label={dict.common.search} placeholder={dict.common.search} className="bg-transparent py-1 text-sm outline-none" />
+        <div className="ml-auto flex items-center gap-1 md:gap-2">
+          <div className="hidden items-center gap-2 rounded-full border px-3.5 py-2 text-muted-foreground transition-colors focus-within:border-ring md:flex">
+            <Search className="size-4" />
+            <input
+              aria-label={dict.common.search}
+              placeholder={dict.common.search}
+              className="w-28 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+            />
           </div>
-          <button aria-label="Account" className="hidden h-11 w-11 items-center justify-center rounded-md hover:bg-muted md:flex">
-            <User className="h-5 w-5" />
+          <button
+            aria-label="Account"
+            className="hidden size-11 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground md:flex"
+          >
+            <User className="size-5" />
           </button>
-          <Link href={`/${locale}/cart`} aria-label={dict.cart.title} className="relative flex h-11 w-11 items-center justify-center rounded-md hover:bg-muted">
-            <ShoppingCart className="h-5 w-5" />
-            {count > 0 ? <span className="absolute right-1.5 top-1.5 min-w-4 rounded-full bg-primary px-1 text-center text-xs leading-4 text-primary-foreground">{count}</span> : null}
+          <Link
+            href={`/${locale}/cart`}
+            aria-label={dict.cart.title}
+            className="relative flex size-11 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <ShoppingBag className="size-5" />
+            {count > 0 ? (
+              <span className="absolute right-1 top-1 flex min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium leading-4 text-primary-foreground">
+                {count}
+              </span>
+            ) : null}
           </Link>
-          <div className="hidden md:block">
+          <div className="ml-1 hidden md:block">
             <LocaleSwitcher currentLocale={locale} />
           </div>
         </div>

--- a/components/layout/mega-nav.tsx
+++ b/components/layout/mega-nav.tsx
@@ -1,17 +1,33 @@
+'use client';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import type { Locale } from '@/lib/i18n/config';
 import type { Dictionary } from '@/lib/i18n/dictionaries';
 import { getNavItems } from './nav-items';
+import { cn } from '@/lib/utils/cn';
 
 export function MegaNav({ locale, dict }: { locale: Locale; dict: Dictionary }) {
   const items = getNavItems(dict);
+  const pathname = usePathname();
   return (
-    <nav className="hidden min-w-0 gap-6 overflow-x-auto md:flex">
-      {items.map((it) => (
-        <Link key={it.slug} href={`/${locale}/collection/${it.slug}`} className="text-sm font-medium hover:text-primary">
-          {it.label}
-        </Link>
-      ))}
+    <nav className="hidden min-w-0 items-center gap-7 md:flex">
+      {items.map((it) => {
+        const href = `/${locale}/collection/${it.slug}`;
+        const active = pathname === href;
+        return (
+          <Link
+            key={it.slug}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={cn(
+              'text-sm transition-colors',
+              active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {it.label}
+          </Link>
+        );
+      })}
     </nav>
   );
 }

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -1,0 +1,76 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils/cn"
+
+const alertVariants = cva(
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-2.5 py-2 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-action"
+      className={cn("absolute top-2 right-2", className)}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription, AlertAction }

--- a/components/ui/aspect-ratio.tsx
+++ b/components/ui/aspect-ratio.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { AspectRatio as AspectRatioPrimitive } from "radix-ui"
+
+function AspectRatio({
+  ...props
+}: React.ComponentProps<typeof AspectRatioPrimitive.Root>) {
+  return <AspectRatioPrimitive.Root data-slot="aspect-ratio" {...props} />
+}
+
+export { AspectRatio }

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,0 +1,122 @@
+import * as React from "react"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils/cn"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+
+function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  asChild,
+  className,
+  ...props
+}: React.ComponentProps<"a"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot.Root : "a"
+
+  return (
+    <Comp
+      data-slot="breadcrumb-link"
+      className={cn("transition-colors hover:text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? (
+        <ChevronRightIcon />
+      )}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn(
+        "flex size-5 items-center justify-center [&>svg]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon
+      />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils/cn"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-(--card-spacing)", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/components/ui/empty.tsx
+++ b/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils/cn"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl border-dashed p-6 text-center text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn("flex max-w-sm flex-col items-center gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn(
+        "font-heading text-sm font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-2.5 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/components/ui/field.tsx
+++ b/components/ui/field.tsx
@@ -1,0 +1,238 @@
+"use client"
+
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils/cn"
+import { Label } from "@/components/ui/label"
+import { Separator } from "@/components/ui/separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-2 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+        horizontal:
+          "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        responsive:
+          "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-0.5 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+}

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils/cn"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils/cn"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils/cn"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/lib/i18n/dictionaries/en.ts
+++ b/lib/i18n/dictionaries/en.ts
@@ -23,6 +23,7 @@ export const en = {
   cart: {
     title: 'Your Cart', empty: 'Your cart is empty', subtotal: 'Subtotal',
     checkout: 'Checkout', remove: 'Remove',
+    orderSummary: 'Order summary', shipping: 'Shipping', free: 'Free', total: 'Total',
   },
   checkout: {
     title: 'Checkout', fullName: 'Full name', email: 'Email', address: 'Address',

--- a/lib/i18n/dictionaries/vi.ts
+++ b/lib/i18n/dictionaries/vi.ts
@@ -25,6 +25,7 @@ export const vi: Dictionary = {
   cart: {
     title: 'Giỏ hàng', empty: 'Giỏ hàng trống', subtotal: 'Tạm tính',
     checkout: 'Thanh toán', remove: 'Xóa',
+    orderSummary: 'Tóm tắt đơn hàng', shipping: 'Vận chuyển', free: 'Miễn phí', total: 'Tổng cộng',
   },
   checkout: {
     title: 'Thanh toán', fullName: 'Họ tên', email: 'Email', address: 'Địa chỉ',


### PR DESCRIPTION
Full storefront redesign following the **design-taste-frontend** + **redesign-existing-projects** methodology, built on **shadcn/ui** (radix-nova) primitives. Direction: clean luxury — neutral true-grey base with a single locked deep-rose accent, Geist display/body.

Verified: `tsc` clean · 26/26 tests · production build (11 pages) · browser QA on home, PLP, PDP, checkout, and dark mode.

## Foundation
- **Geist** display + body — drops discouraged Inter and the methodology-banned Fraunces serif; also fixes a pre-existing bug where `--font-sans` was self-referential (font loaded but never bound)
- **Neutral base + single deep-rose accent**, locked across light + dark tokens
- Heading tracking/balance, smooth scroll

## Layout
- Quiet ink announcement bar; sticky blurred header with tracked wordmark, pill search, ghost icon buttons, active-page nav indication
- Editorial simplified footer

## Components (rebuilt on shadcn + luxury treatment)
- Borderless product card with crossfade-on-hover image; rose sale pricing
- Editorial hero (overlay headline, CTA, dot indicators) + full-width category tiles
- PDP: `Breadcrumb`, buy box with `Separator` + freeship, spec sheet as a **hairline tile grid** (methodology bans row-tables), reviews with `Empty` state
- Filters as shadcn `Select`; collection `Empty` state + count
- Cart / checkout / success on `Card` / `FieldGroup`+`Field` / `Empty`; `Alert` error summary
- Ink rating stars (removes raw amber)

## Notable fix
The main content column was **shrink-wrapping to ~600px** under the `flex-col` body on every page (pre-existing). Added `w-full` so it fills `max-w-7xl` — this widened the entire site.

Adds shadcn components: card, separator, skeleton, empty, alert, aspect-ratio, breadcrumb, label, field.

## Follow-ups (out of scope)
- Product/hero imagery are placeholder assets — realistic photography needs real assets
- Search still isn't wired to a results route; footer policy links still point home

🤖 Generated with [Claude Code](https://claude.com/claude-code)